### PR TITLE
Add num agents parameter

### DIFF
--- a/cmd/main/basicSystem/basicSystem_test.go
+++ b/cmd/main/basicSystem/basicSystem_test.go
@@ -20,7 +20,7 @@ func TestBasicSystem(t *testing.T) {
 		[]float64{0.0, 0.0, 0.0, 0.2, 0.2, 0.2, 0.2, 0.2},
 		0,
 		math.Pow10(-6))
-	manager := manager.NewManager(&targetSystem, 100, 8, geneticBreeder, false)
+	manager := manager.NewManager(&targetSystem, 100, 100, 8, geneticBreeder, false)
 	manager.SimulateManyGenerations(100)
 
 	os.RemoveAll("data")

--- a/cmd/main/multiAgentSystem/multiAgentSystem_test.go
+++ b/cmd/main/multiAgentSystem/multiAgentSystem_test.go
@@ -20,7 +20,7 @@ func TestMultiAgentSystem(t *testing.T) {
 		[]float64{0.0, 0.0, 0.0, 0.2, 0.2, 0.2, 0.2, 0.2},
 		2,
 		math.Pow10(-6))
-	manager := manager.NewManager(&targetSystem, 10, 8, geneticBreeder, false)
+	manager := manager.NewManager(&targetSystem, 100, 10, 8, geneticBreeder, false)
 	manager.SimulateManyGenerations(100)
 
 	os.RemoveAll("data")

--- a/pkg/Manager/Manager.go
+++ b/pkg/Manager/Manager.go
@@ -99,12 +99,12 @@ func NewManager(system system.System, numAgents int, numSimulationsPerGeneration
 // Simulate a single repetition, of which there may be many (always at least one) within a generation
 // This method is not exposed publicly. The intention is for users to call SimulateGeneration instead.
 func (manager *Manager) simulateRepetition() error {
-	numAgentsPerSimulation := manager.system.NumAgentsPerSimulation()
+	numSimulations := len(manager.currentGeneration) / manager.system.NumAgentsPerSimulation()
 
 	// Channel to send collections of agents through to simulation goroutines.
 	// The number of agents sent at once is equal to the number of agents required
 	// for one simulation.
-	agentChannel := make(chan []*agent.Agent, manager.numSimulationsPerGeneration)
+	agentChannel := make(chan []*agent.Agent, numSimulations)
 	// Channel to receive signals (hence generic struct{}) for when a simulation finishes.
 	simulationFinishedSignalChannel := make(chan struct{})
 	// A simple counter of how many simulations are running
@@ -119,10 +119,10 @@ func (manager *Manager) simulateRepetition() error {
 	utils.ShuffleSlice(manager.randomGenerator, manager.currentGeneration)
 
 	// Actually start all the simulations
-	for simulationIndex := 0; simulationIndex < manager.numSimulationsPerGeneration; simulationIndex++ {
+	for simulationIndex := 0; simulationIndex < numSimulations; simulationIndex++ {
 		simulationsRunningCounter += 1
 		// Find the agents to be used in this simulation
-		simulationAgents := manager.currentGeneration[numAgentsPerSimulation*simulationIndex : numAgentsPerSimulation*(simulationIndex+1)]
+		simulationAgents := manager.currentGeneration[manager.system.NumAgentsPerSimulation()*simulationIndex : manager.system.NumAgentsPerSimulation()*(simulationIndex+1)]
 		// Send the agents to the simulators - blocks until agents can be taken
 		agentChannel <- simulationAgents
 	}

--- a/pkg/Manager/Manager.go
+++ b/pkg/Manager/Manager.go
@@ -42,12 +42,15 @@ type Manager struct {
 //
 // System given must fully implement the System interface in `pkg/system`
 //
+// numAgents defines how many agents should be created. This should be a reasonable number for your system!
+// i.e. if your system requires 2 agents per simulation, this number should be even.
+//
 // numSimulationsPerGeneration defines how many simulations to run before tallying up the agents
 // scores and breeding a new generation. A large number is better, as it averages agent
 // performance.
 //
 // verbose is a bool flag determining if logs are printed to stdout as well as the log file
-func NewManager(system system.System, numSimulationsPerGeneration int, numThreads int, geneticBreeder *geneticbreeder.GeneticBreeder, verbose bool) *Manager {
+func NewManager(system system.System, numAgents int, numSimulationsPerGeneration int, numThreads int, geneticBreeder *geneticbreeder.GeneticBreeder, verbose bool) *Manager {
 	os.MkdirAll(path.Dir(DATA_DIRECTORY), 0700)
 	os.MkdirAll(path.Dir(LOG_FILE_PATH), 0700)
 
@@ -64,7 +67,6 @@ func NewManager(system system.System, numSimulationsPerGeneration int, numThread
 	}
 	logger := log.New(multiWriter, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
 
-	numAgents := system.NumAgentsPerSimulation() * numSimulationsPerGeneration
 	currentGeneration := make([]*agent.Agent, numAgents)
 	for agentIndex := range currentGeneration {
 		currentGeneration[agentIndex] = agent.NewRandomGaussianAgent(system.NumActions(), system.NumPercepts())

--- a/pkg/Manager/Manager.go
+++ b/pkg/Manager/Manager.go
@@ -76,6 +76,10 @@ func NewManager(system system.System, numAgents int, numSimulationsPerGeneration
 		panic("Number of threads must be a positive integer!")
 	}
 
+	if numAgents%system.NumAgentsPerSimulation() != 0 {
+		panic("numAgents must be divisible by system.NumAgentsPerSimulation!")
+	}
+
 	randomGenerator := rand.New(rand.NewSource(uint64(time.Now().Nanosecond())))
 
 	return &Manager{


### PR DESCRIPTION
Allows users to specify how many agents to train, rather than this being set by another (unrelated) parameter